### PR TITLE
Feat-get-applications-endpoint

### DIFF
--- a/app/core/audit.py
+++ b/app/core/audit.py
@@ -35,58 +35,61 @@ def create_package_payload(packages: list[Package]) -> dict:
     for package in packages:
         queries.append({
             "package": {
-                "name": package.name,
+                "name": package["name"],
                 "ecosystem": "PyPI"
             },
-            "version": package.version
+            "version": package["version"]
         })
     return {"queries": queries}
 
 
 def update_vulnerabilities(
-        app: Application,
+        app_id: int,
         packages: list[Package],
         vulnerabilities: list[dict],
         session_provider: Generator[Session, None, None]) -> None:
     """
     Uses the data from the Audit service to update local packages
     and the linked application vulnerability status.
-    :param app: the registered Application using those packages.
+    :param app_id: the Id of the registered Application using those packages.
     :param packages: a list of packages registered on the database.
     :param vulnerabilities: the list of vulnerabilities from the response
     of the audit system.
     :param session_provider: a generator that provides a database session.
     """
     with next(session_provider()) as session:
+    #with Session(session_provider) as session: 
         vulnerabilities_found = 0
         for i in range(len(packages)):
+            package = session.get(Package, packages[i]["id"])
             if not vulnerabilities[i]:
-                packages[i].is_secure = True
+                package.is_secure = True
             else: 
-                packages[i].is_secure = False
+                package.is_secure = False
                 vulnerabilities_found+=1
-            session.add(packages[i])
-        
-        app.is_secure = False if vulnerabilities_found > 0 else True
-        session.add(app)
+            session.add(package)
+        appi = session.get(Application, app_id)
+        appi.is_secure = False if vulnerabilities_found > 0 else True
+        session.add(appi)
         session.commit()
 
 
 def registration_task(
-        app: Application, 
+        app_id: Application,
         req_content: bytes,
         session_provider: Generator[Session, None, None]) -> None:
     """
     Main audit function, combining all logic from package registration, fetching
     vulnerabilities and updating the secure status of packages and the application.
-    :param app: the Application instance being registered.
+    :param app_id: the Id of the Application instance being registered.
     :param req_content: the content read of the requirements file uploaded.
     :param session_provider: a generator for a session on the database.
     """
-    packages = process_requirements_packages(session_provider, req_content)
+    packages = process_requirements_packages(app_id, session_provider, req_content)
     if not packages:
         return
     payload = create_package_payload(packages)
     report = get_vulnerabilities(payload)
     vulnerabilities = report.get("results")
-    update_vulnerabilities(app, packages, vulnerabilities, session_provider)
+    # TODO use the app id to find all the packages
+    update_vulnerabilities(app_id, packages, vulnerabilities, session_provider)

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -2,7 +2,7 @@ from typing import Generator
 
 from sqlmodel import create_engine, SQLModel, Session
 
-from app.core.models import Application, Package
+from app.core.models import Application, Package, AppDependencyLink
 from app.core.config import settings
 
 

--- a/app/core/file_handling.py
+++ b/app/core/file_handling.py
@@ -3,7 +3,7 @@ from fastapi import UploadFile, HTTPException, status
 from sqlmodel import Session, select
 from sqlalchemy.exc import NoResultFound
 from packaging.requirements import Requirement, InvalidRequirement, SpecifierSet
-from app.core.models import Package
+from app.core.models import Package, Application, AppDependencyLink
 from app.core.config import settings
 
 
@@ -69,8 +69,9 @@ def get_osv_version(specifiers: SpecifierSet) -> str:
 
 
 def process_requirements_packages(
+        app_id: int,
         session_provider: Generator[Session, None, None], 
-        requirements_content: bytes) -> list[Package]:
+        requirements_content: bytes) -> list[dict]:
     """
     Processes the given content of the requirements uploaded file and creates
     package entries in the database of the supported elements.
@@ -82,18 +83,36 @@ def process_requirements_packages(
     process_packages = [create_package(line) for line in package_lines if create_package(line) is not None]
     result_packages = []
     with next(session_provider()) as session:
+    #with Session(session_provider) as session:
+        app = session.get(Application, app_id)
         for package in process_packages:
             query = select(Package).where(
-                Package.name == package.name, 
+                Package.name == package.name,
                 Package.version == package.version)
             try:
                 existing = session.exec(query).one()
-                result_packages.append(existing)
+                result_packages.append(
+                    {"name": existing.name, "version": existing.version, "id": existing.id})
+                existing_link = session.exec(
+                    select(AppDependencyLink).where(
+                        AppDependencyLink.app_id == app.id,
+                        AppDependencyLink.package_id == existing.id,
+                    )
+                ).first()
+                if not existing_link:
+                    app.dependencies.append(existing)
             except NoResultFound:
+                package.apps.append(app)
                 session.add(package)
-                result_packages.append(package)
+                result_packages.append(
+                    {"name": package.name, "version": package.version, "id": package.id})
+                existing_link = session.exec(
+                    select(AppDependencyLink).where(
+                        AppDependencyLink.app_id == app.id,
+                        AppDependencyLink.package_id == package.id,
+                    )
+                ).first()
+                if not existing_link:
+                    app.dependencies.append(package)
         session.commit()
-        for package in result_packages:
-            if package in process_packages:  # only those created in this session
-                session.refresh(package)
     return result_packages

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1,6 +1,10 @@
 from typing import Optional
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Relationship
 
+
+class AppDependencyLink(SQLModel, table=True):
+    app_id: int | None = Field(default=None, foreign_key="application.id", primary_key=True)
+    package_id: int | None = Field(default=None, foreign_key="package.id", primary_key=True)
 
 class Application(SQLModel, table=True):
     """Represents a Python application table schema."""
@@ -8,7 +12,7 @@ class Application(SQLModel, table=True):
     name: str = Field(index=True, max_length=80)
     description: str = Field(default=None, max_length=255)
     is_secure: Optional[bool] = None
-    #dependencies: list[int] = Field(default=[])
+    dependencies: list["Package"] = Relationship(back_populates="apps", link_model=AppDependencyLink)
 
 class Package(SQLModel, table=True):
     """Represents a Python package table schema."""
@@ -16,4 +20,4 @@ class Package(SQLModel, table=True):
     name: str = Field(index=True)
     version: Optional[str] = None
     is_secure: Optional[bool] = None
-    #apps: list[int] = Field(default=[])
+    apps: list["Application"] = Relationship(back_populates="dependencies", link_model=AppDependencyLink)

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from .routers.apps import app_router
+from .routers.packages import package_router
 from .core.database import create_db_and_tables
 
 
@@ -17,6 +18,7 @@ async def lifespan(api_app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 app.include_router(app_router)
+app.include_router(package_router)
 
 @app.get("/")
 async def root():

--- a/app/routers/apps.py
+++ b/app/routers/apps.py
@@ -1,9 +1,9 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
-from fastapi import Form, UploadFile, BackgroundTasks
+from fastapi import Form, UploadFile
 
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.core.models import Application
 from app.core.database import get_session
@@ -22,23 +22,27 @@ async def create_application(
     *, session: Session = Depends(get_session),
     name: Annotated[str, Form()],
     description: Annotated[str, Form()],
-    requirements_file: UploadFile = Depends(validate_requirement_file), 
-    background_tasks: BackgroundTasks):
+    requirements_file: UploadFile = Depends(validate_requirement_file)):
     """
     Registers the application using the given data as well as creating
     package entries from the dependencies found in the uploaded file.
     """
-    registered = Application(name=name, description=description)
-    session.add(registered)
-    session.commit()
-    session.refresh(registered)
+    exists = session.exec(Application).where(
+        Application.name == name, 
+        Application.description == description).first()
+    if not exists:
+        registered = Application(name=name, description=description)
+        session.add(registered)
+        session.commit()
+        session.refresh(registered)
     file_content = await requirements_file.read()
-    background_tasks.add_task(
-        registration_task,
-        Application(
-            name=registered.name, 
-            description=registered.description, 
-            id=registered.id),  # make a copy to avoid it being stale
-        file_content,
-        get_session)
+    registration_task(registered.id if not exists else exists.id, file_content, get_session)
     return registered
+
+@app_router.get(
+        "/applications/",
+        tags=["applications"],
+        status_code=status.HTTP_200_OK,
+        response_model=list[Application])
+async def get_applications(*, session: Session = Depends(get_session)):
+    return session.exec(select(Application)).all()

--- a/app/routers/packages.py
+++ b/app/routers/packages.py
@@ -1,0 +1,33 @@
+from typing import Annotated
+from fastapi import APIRouter, Depends, status
+from sqlmodel import Session, select
+from app.core.models import Package
+from app.core.database import get_session
+
+
+package_router = APIRouter()
+
+@package_router.get(
+        "/dependencies/",
+        tags=["dependencies"],
+        status_code=status.HTTP_200_OK,
+        response_model=list[Package])
+async def create_application(
+    *, session: Session = Depends(get_session)):
+    """
+    List all dependencies tracked across the user’s applications.
+    Identify vulnerable dependencies.
+    """
+    return session.exec(select(Package)).all()
+
+@package_router.get(
+        "/dependency/",
+        tags=["dependencies"],
+        status_code=status.HTTP_200_OK,
+        response_model=Package)
+async def get_applications(*, session: Session = Depends(get_session)):
+    """
+    Provide details about a specific dependency, 
+    including usage and associated vulnerabilities
+    """
+    return session.get(Package, id).one()

--- a/tests/test_router_apps.py
+++ b/tests/test_router_apps.py
@@ -9,8 +9,9 @@ from app.main import app
 from app.core.models import Application, Package
 
 
-API_URL = "/register/"
+REGISTRATION_URL = "/register/"
 TEST_APP_PARAMS = {"name": "Test Application", "description": "Test Description"}
+LIST_APPLICATIONS_URL = "/applications/"
 
 def get_test_file_params() -> dict:
     """Provides a test dict for an uploaded file request,"""
@@ -50,19 +51,19 @@ def client_fixture(session: Session):
 
 
 def test_create_application_given_all_parameters_returns_created(client: TestClient):
-    response = client.post(API_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
+    response = client.post(REGISTRATION_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
     assert response.status_code == status.HTTP_201_CREATED
 
 def test_create_application_given_valid_request_returns_createsd_application(
         client: TestClient):
-    response = client.post(API_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
+    response = client.post(REGISTRATION_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
     result = response.json()
     expected = {"id": 1, "name": "Test Application", "description": "Test Description", "is_secure": None}
     assert result == expected
 
 def test_create_application_given_valid_request_creates_application(
         client: TestClient, session: Session):
-    client.post(API_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
+    client.post(REGISTRATION_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
     created = session.exec(select(Application).where(Application.name == "Test Application")).first()
     assert created is not None
     assert created.name == "Test Application"
@@ -70,7 +71,7 @@ def test_create_application_given_valid_request_creates_application(
 
 def test_create_application_missing_name_returns_unprocessable(client: TestClient):
     response = client.post(
-        API_URL,
+        REGISTRATION_URL,
         data={"description": "Test Description"},
         files=get_test_file_params(),
     )
@@ -78,32 +79,42 @@ def test_create_application_missing_name_returns_unprocessable(client: TestClien
 
 def test_create_application_missing_description_returns_unprocessable(client: TestClient):
     response = client.post(
-        API_URL,
+        REGISTRATION_URL,
         data={"name": "Test Application"},
         files=get_test_file_params(),
     )
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 def test_create_application_missing_requirements_returns_unprocessable(client: TestClient):
-    response = client.post(API_URL, data=TEST_APP_PARAMS)
+    response = client.post(REGISTRATION_URL, data=TEST_APP_PARAMS)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 def test_create_application_on_validation_failure_returns_unprocessable(client: TestClient):
     app.dependency_overrides[validate_requirement_file] = mock_invalid_requirements_file
-    response = client.post(API_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
+    response = client.post(REGISTRATION_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     app.dependency_overrides.clear()
 
 def test_create_application_given_valid_request_triggers_requirements_processing(
         mocker, client: TestClient):
     mock_background_task = mocker.spy(BackgroundTasks, "add_task")
-    response = client.post(API_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
+    response = client.post(REGISTRATION_URL, data=TEST_APP_PARAMS, files=get_test_file_params())
     assert response.status_code == status.HTTP_201_CREATED
     mock_background_task.assert_called_once()
 
 def test_create_application_missing_requiremetns_file_does_not_trigger_requirements_processing(
         mocker, client: TestClient):
     mock_background_task = mocker.spy(BackgroundTasks, "add_task")
-    response = client.post(API_URL, data=TEST_APP_PARAMS)
+    response = client.post(REGISTRATION_URL, data=TEST_APP_PARAMS)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     mock_background_task.assert_not_called()
+
+
+def test_get_applications_returns_ok_and_registered_applications(
+        client: TestClient, session: Session):
+    registered_app = Application(name="included", description="testing application")
+    session.add(registered_app)
+    session.commit()
+    response = client.get(LIST_APPLICATIONS_URL)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == [{"name": "included", "description": "testing application", "id": 1, "is_secure": None}]


### PR DESCRIPTION
Inlution of the missing endpoints for package dependencies.
A big refactoring of the application registration logic to be all done directly on the registration endpoint because of issues with the inmemory database during session generation in a bacground task.